### PR TITLE
Support adding operations

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -9,10 +9,7 @@ module JSONLogic
     values = [values] unless values.is_a?(Array)         # syntactic sugar
     new_vals = values.map { |value| apply(value, data) } # recursion step
     new_vals.flatten!(1) if new_vals.size == 1           # [['A']] => ['A']
-    if Operation.is_standard?(operator)                  # perform operation if standard
-      return Operation.perform(operator, new_vals, data || {})
-    end
-    JSONLogic.send(operator, new_vals, data || {})       # perform custom operation
+    Operation.perform(operator, new_vals, data || {})    # perform operation
   end
 
   def self.filter(logic, data)
@@ -20,8 +17,8 @@ module JSONLogic
   end
 
   def self.add_operation(operator, function)
-    self.class.send(:define_method, operator) do |v, d|
-      function[v, d]
+    Operation.class.send(:define_method, operator) do |v, d|
+      function.call(v, d)
     end
   end
 end

--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -9,11 +9,20 @@ module JSONLogic
     values = [values] unless values.is_a?(Array)         # syntactic sugar
     new_vals = values.map { |value| apply(value, data) } # recursion step
     new_vals.flatten!(1) if new_vals.size == 1           # [['A']] => ['A']
-    Operation.perform(operator, new_vals, data || {})    # perform operation
+    if Operation.is_standard?(operator)                  # perform operation if standard
+      return Operation.perform(operator, new_vals, data || {})
+    end
+    JSONLogic.send(operator, new_vals, data || {})       # perform custom operation
   end
 
   def self.filter(logic, data)
     data.select { |d| apply(logic, d) }
+  end
+
+  def self.add_operation(operator, function)
+    self.class.send(:define_method, operator) do |v, d|
+      function[v, d]
+    end
   end
 end
 

--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -43,11 +43,18 @@ module JSONLogic
     }
 
     def self.perform(operator, values, data)
-      LAMBDAS[operator].call(values, data)
+      return LAMBDAS[operator].call(values, data) if is_standard?(operator)
+      send(operator, values, data)
     end
 
     def self.is_standard?(operator)
       LAMBDAS.keys.include?(operator)
+    end
+
+    def self.add_operation(operator, function)
+      self.class.send(:define_method, operator) do |v, d|
+        function.call(v, d)
+      end
     end
   end
 end

--- a/lib/json_logic/operation.rb
+++ b/lib/json_logic/operation.rb
@@ -45,5 +45,9 @@ module JSONLogic
     def self.perform(operator, values, data)
       LAMBDAS[operator].call(values, data)
     end
+
+    def self.is_standard?(operator)
+      LAMBDAS.keys.include?(operator)
+    end
   end
 end

--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,3 +1,3 @@
 module JSONLogic
-  VERSION = '0.1'
+  VERSION = '0.2'
 end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -25,4 +25,12 @@ class JSONLogicTest < Minitest::Test
     data = JSON.parse(%Q|[{"id": 1},{"id": 2}]|)
     assert_equal([{'id' => 2}], JSONLogic.filter(filter, data))
   end
+
+  def test_add_operation
+    new_operation = ->(v, d) { v.map { |x| x + 5 } }
+    JSONLogic.add_operation('fives', new_operation)
+    rules = JSON.parse(%Q|{"fives": {"var": "num"}}|)
+    data = JSON.parse(%Q|{"num": 1}|)
+    assert_equal([6], JSONLogic.apply(rules, data))
+  end
 end


### PR DESCRIPTION
The main JSONLogic library [added support for defining custom methods](https://github.com/jwadhams/json-logic-js/commit/5809e641b050fa69700eec0c11c39d0501de056e), so I took a crack at porting over.  I tried to keep the footprint minimal.